### PR TITLE
Deprecate members & invite events in favor of applicationMember & applicationInvite aliases

### DIFF
--- a/src/balena-event-log.js
+++ b/src/balena-event-log.js
@@ -104,6 +104,7 @@ var EVENTS = {
 // TODO: Completely replace the members namespace (which in the orgs era is ambiguous)
 // with applicationMember once the analytics team has a good event migration approach.
 var ALIASSED_EVENT_NAMESPACES = {
+	invite: 'applicationInvite',
 	members: 'applicationMember',
 };
 

--- a/src/balena-event-log.js
+++ b/src/balena-event-log.js
@@ -101,6 +101,12 @@ var EVENTS = {
 	invite: ['addInviteOpen', 'create', 'delete', 'accept'],
 };
 
+// TODO: Completely replace the members namespace (which in the orgs era is ambiguous)
+// with applicationMember once the analytics team has a good event migration approach.
+var ALIASSED_EVENT_NAMESPACES = {
+	members: 'applicationMember',
+};
+
 var DEFAULT_HOOKS = {
 	beforeCreate: function (
 		_type,
@@ -271,6 +277,10 @@ module.exports = function (options) {
 				);
 			};
 		});
+		var aliasedNamespace = ALIASSED_EVENT_NAMESPACES[base];
+		if (aliasedNamespace) {
+			eventLog[aliasedNamespace] = eventLog[base];
+		}
 	});
 
 	return eventLog;

--- a/typings/balena-event-log.d.ts
+++ b/typings/balena-event-log.d.ts
@@ -108,6 +108,7 @@ declare namespace BalenaEventLog {
 			delete: TrackFunction;
 			pinToRelease: TrackFunction;
 		};
+		applicationMember: IHaveCreateEditDelete;
 		applicationTag: IHaveCreateEditDelete & {
 			set: TrackFunction;
 		};
@@ -172,6 +173,7 @@ declare namespace BalenaEventLog {
 		releaseTag: IHaveCreateEditDelete & {
 			set: TrackFunction;
 		};
+		/** @deprecated Use applicationMember */
 		members: IHaveCreateEditDelete;
 		billing: {
 			paymentInfoUpdate: TrackFunction;

--- a/typings/balena-event-log.d.ts
+++ b/typings/balena-event-log.d.ts
@@ -109,6 +109,7 @@ declare namespace BalenaEventLog {
 			pinToRelease: TrackFunction;
 		};
 		applicationMember: IHaveCreateEditDelete;
+		applicationInvite: Invite;
 		applicationTag: IHaveCreateEditDelete & {
 			set: TrackFunction;
 		};
@@ -190,6 +191,7 @@ declare namespace BalenaEventLog {
 		navigation: {
 			click: TrackFunction;
 		};
+		/** @deprecated Use applicationInvite */
 		invite: Invite;
 	}
 


### PR DESCRIPTION
This just aliases the methods, while still sending (for now) the exact same events.

Change-type: minor
See: https://www.flowdock.com/app/rulemotion/r-thefunnel/threads/6C2TuFBrTaf1krKgqph0gEq4ewr