### PR TITLE
Add tracking for copying Block image references

### DIFF
--- a/src/balena-event-log.js
+++ b/src/balena-event-log.js
@@ -37,6 +37,7 @@ var EVENTS = {
 		'delete',
 		'pinToRelease',
 	],
+	block: ['imageReferenceCopy'],
 	applicationTag: ['set', 'create', 'edit', 'delete'],
 	applicationMembers: ['create', 'edit', 'delete'],
 	configVariable: ['create', 'edit', 'delete'],

--- a/typings/balena-event-log.d.ts
+++ b/typings/balena-event-log.d.ts
@@ -108,6 +108,9 @@ declare namespace BalenaEventLog {
 			delete: TrackFunction;
 			pinToRelease: TrackFunction;
 		};
+		block: {
+			imageReferenceCopy: TrackFunction;
+		}
 		applicationMember: IHaveCreateEditDelete;
 		applicationInvite: Invite;
 		applicationTag: IHaveCreateEditDelete & {


### PR DESCRIPTION
Add tracking for copying Block image references

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>